### PR TITLE
Adds toArray of JSON objects support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ grunt.loadNpmTasks('grunt-merge-json');
 
 - `replacer`: (default `null`) the replacer argument for `JSON.stringify()` (second argument).
 - `space`: (default `\t`) the space argument for `JSON.stringify()` (third argument).
+- `isArray`: (default `false`) merge to an array.
 
 ## Merge JSON Task
 
@@ -100,6 +101,41 @@ grunt.initConfig({
         }
     }
 });
+```
+
+### Single file per target (as array)
+
+```js
+grunt.initConfig({
+    "merge-json": {
+        "options": {
+            "toArray": true
+        },
+        "en": {
+            src: [ "src/**/*-en.json" ],
+            dest: "www/en.json"
+        }
+    }
+})
+```
+
+ - `www/en.json`:
+
+```json
+[
+    {
+        "foo": {
+            "title": "The Foo",
+            "name":  "A wonderful component"
+        }
+    },
+    {
+        "bar": {
+            "title": "The Bar",
+            "name":  "An even more wonderful component"
+        }
+    }
+]
 ```
 
 ### Multiple files per target variant

--- a/tasks/grunt-merge-json.js
+++ b/tasks/grunt-merge-json.js
@@ -32,7 +32,8 @@ module.exports = function (grunt) {
         /*  prepare options  */
         var options = this.options({
             replacer: null,
-            space: "\t"
+            space: "\t",
+            toArray: false
         });
         grunt.verbose.writeflags(options, "Options");
 
@@ -40,7 +41,7 @@ module.exports = function (grunt) {
         this.files.forEach(function (f) {
             try {
                 /*  start with an empty object  */
-                var json = {};
+                var json = options.toArray ? [] : {};
                 f.src.forEach(function (src) {
                     /*  merge JSON file into object  */
                     if (!grunt.file.exists(src))
@@ -50,9 +51,13 @@ module.exports = function (grunt) {
                         grunt.log.debug("reading JSON source file \"" + chalk.green(src) + "\"");
                         try { fragment = grunt.file.readJSON(src); }
                         catch (e) { grunt.fail.warn(e); }
-                        json = _.merge(json, fragment, function (a, b) {
-                            return _.isArray(a) ? a.concat(b) : undefined;
-                        });
+                        if (_.isArray(json)) {
+                            json.push(fragment);
+                        } else {
+                            json = _.merge(json, fragment, function (a, b) {
+                                return _.isArray(a) ? a.concat(b) : undefined;
+                            });
+                        }
                     }
                 });
 


### PR DESCRIPTION
Supports serialization of objects into an array instead of merging into hash. Adds a property to `options` (`isArray` Boolean = false). Updates docs.

Closes [#10](https://github.com/rse/grunt-merge-json/issues/10)