### PR TITLE
Added functionality to merge arrays without duplicates

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "chalk":                "~0.5.1",
-        "lodash":               "~2.4.1"
+        "lodash":               "~4.0.0"
     },
     "engines": {
         "node":                 ">=0.10.0"

--- a/tasks/grunt-merge-json.js
+++ b/tasks/grunt-merge-json.js
@@ -51,7 +51,7 @@ module.exports = function (grunt) {
                         try { fragment = grunt.file.readJSON(src); }
                         catch (e) { grunt.fail.warn(e); }
                         json = _.merge(json, fragment, function (a, b) {
-                            return _.isArray(a) ? a.concat(b) : undefined;
+                            return _.isArray(a) ? _.uniqWith(a.concat(b), _.isEqual) : undefined;
                         });
                     }
                 });

--- a/tasks/grunt-merge-json.js
+++ b/tasks/grunt-merge-json.js
@@ -50,7 +50,7 @@ module.exports = function (grunt) {
                         grunt.log.debug("reading JSON source file \"" + chalk.green(src) + "\"");
                         try { fragment = grunt.file.readJSON(src); }
                         catch (e) { grunt.fail.warn(e); }
-                        json = _.merge(json, fragment, function (a, b) {
+                        json = _.mergeWith(json, fragment, function (a, b) {
                             return _.isArray(a) ? _.uniqWith(a.concat(b), _.isEqual) : undefined;
                         });
                     }


### PR DESCRIPTION
I changed the form arrays are merged, so the merged array doesn't contain duplicates.

For Example if you have the jsons

```javascript
{
    "array": [1,2,3]
}
{
    "array": [2,3,4]
}
```

You get

```javascript
{
    "array": [1,2,3,4]
}
```